### PR TITLE
feat: update models to qwen3-coder series and optimize routing

### DIFF
--- a/__tests__/claude-code-router-config.test.js
+++ b/__tests__/claude-code-router-config.test.js
@@ -189,6 +189,15 @@ describe("ClaudeCodeRouterConfig", () => {
       expect(configContent).toHaveProperty("Router");
       expect(configContent.transformers).toHaveLength(1);
       expect(configContent.Providers).toHaveLength(1);
+      
+      // Check models configuration
+      expect(configContent.Providers[0].models).toEqual(["qwen3-coder-plus", "qwen3-coder-flash"]);
+      
+      // Check router configuration
+      expect(configContent.Router.default).toBe("dashscope,qwen3-coder-plus");
+      expect(configContent.Router.think).toBe("dashscope,qwen3-coder-plus");
+      expect(configContent.Router.background).toBe("dashscope,qwen3-coder-flash");
+      expect(configContent.Router.longContext).toBe("dashscope,qwen3-coder-plus");
     });
   });
 

--- a/bin/claude-code-router-config.js
+++ b/bin/claude-code-router-config.js
@@ -186,17 +186,17 @@ class ClaudeCodeRouterConfig {
           api_base_url:
             "https://dashscope.aliyuncs.com/compatible-mode/v1/chat/completions",
           api_key: dashscopeApiKey,
-          models: ["qwen3-235b-a22b"],
+          models: ["qwen3-coder-plus", "qwen3-coder-flash"],
           transformer: {
             use: ["dashscope"],
           },
         },
       ],
       Router: {
-        default: "dashscope,qwen3-235b-a22b",
-        think: "dashscope,qwen3-235b-a22b",
-        background: "dashscope,qwen3-235b-a22b",
-        longContext: "dashscope,qwen3-235b-a22b",
+        default: "dashscope,qwen3-coder-plus",
+        think: "dashscope,qwen3-coder-plus",
+        background: "dashscope,qwen3-coder-flash",
+        longContext: "dashscope,qwen3-coder-plus",
       },
     };
 


### PR DESCRIPTION
- Replace qwen3-235b-a22b with qwen3-coder-plus and qwen3-coder-flash
- Optimize router configuration for different scenarios:
  - default/think/longContext: use qwen3-coder-plus (stronger model)
  - background: use qwen3-coder-flash (faster model)
- Update test cases to validate new model configurations
- Ensure all routing configurations work correctly