### PR TITLE
fix: remove stream property from DashScopeTransformer class

### DIFF
--- a/bin/claude-code-router-config.js
+++ b/bin/claude-code-router-config.js
@@ -264,13 +264,11 @@ class ClaudeCodeRouterConfig {
   constructor(options) {
     this.max_tokens = options.max_tokens || 8192;
     this.enable_thinking = options.enable_thinking || false;
-    this.stream = options.stream || true;
   }
 
   async transformRequestIn(request, provider) {
     request.max_tokens = this.max_tokens;
     request.enable_thinking = this.enable_thinking;
-    request.stream = this.stream;
     return request;
   }
 }


### PR DESCRIPTION
#17 

如果 claude code 原始请求没有 stream 参数，这时 dashscope transformer 补上 stream 参数，返回结果流 ContentType = text/event-stream，但是 claude-code-router 中会当成 json 返回处理（根据原始请求参数来判断的）。这时候会出现 #17 中的错误